### PR TITLE
Add django-instant to requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 cent
+django-instant
 django-cors-headers


### PR DESCRIPTION
This fixes the "No module named 'instant' " when the project is ran.